### PR TITLE
Split transactions into journal entry and line tables

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -1,15 +1,11 @@
 # app/api/routes/__init__.py
 from fastapi import APIRouter
+
 from app.api.routes.chart import router as chart_router
+from app.api.routes.transactions import router as transactions_router
 
 router = APIRouter()
-router.include_router(chart_router)  
+router.include_router(chart_router)
+router.include_router(transactions_router)
 
 __all__ = ["router"]
-
-# from app.api.routes.auth import router as auth_router
-# from app.api.routes.users import router as users_router
-# from app.api.routes.transactions import router as transactions_router
-# router.include_router(auth_router, prefix="/auth", tags=["auth"])
-# router.include_router(users_router, prefix="/users", tags=["users"])
-# router.include_router(transactions_router, prefix="/transactions", tags=["transactions"])

--- a/app/api/routes/transactions.py
+++ b/app/api/routes/transactions.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+from app.models.transaction import JournalEntry
+from app.services.transaction_service import (
+    create_journal_entry,
+    list_journal_entries,
+)
+
+router = APIRouter(prefix="/transactions", tags=["transactions"])
+
+
+@router.post("/")
+def create_entry(entry: JournalEntry):
+    return create_journal_entry(entry)
+
+
+@router.get("/")
+def get_entries():
+    return list_journal_entries()

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -4,5 +4,9 @@ from sqlmodel import SQLModel, create_engine
 engine = create_engine("sqlite:///database.db", echo=True)
 
 def init_db():
-    from app.models.chart_of_account import ChartOfAccount  # import all models here
+    """Create database tables."""
+    # Import models so SQLModel is aware of them
+    from app.models.chart_of_account import ChartOfAccount  # noqa: F401
+    from app.models.transaction import JournalEntry, JournalLine  # noqa: F401
+
     SQLModel.metadata.create_all(engine)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,9 @@
+from .chart_of_account import AccountCategory, ChartOfAccount
+from .transaction import JournalEntry, JournalLine
+
+__all__ = [
+    "AccountCategory",
+    "ChartOfAccount",
+    "JournalEntry",
+    "JournalLine",
+]

--- a/app/models/transaction.py
+++ b/app/models/transaction.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from sqlmodel import Field, Relationship, SQLModel
+
+from app.models.chart_of_account import ChartOfAccount
+
+
+class JournalEntry(SQLModel, table=True):
+    """Represents a single journal entry/transaction."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    description: Optional[str] = None
+    date: datetime = Field(default_factory=datetime.utcnow)
+
+    # relationship
+    lines: List["JournalLine"] = Relationship(back_populates="entry")
+
+
+class JournalLine(SQLModel, table=True):
+    """Line items for a journal entry defining debit/credit amounts."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    entry_id: int = Field(foreign_key="journalentry.id")
+    account_id: int = Field(foreign_key="chartofaccount.id")
+
+    debit: float = 0
+    credit: float = 0
+
+    # relationships
+    entry: JournalEntry = Relationship(back_populates="lines")
+    account: Optional[ChartOfAccount] = Relationship()
+
+
+__all__ = ["JournalEntry", "JournalLine"]

--- a/app/services/transaction_service.py
+++ b/app/services/transaction_service.py
@@ -1,3 +1,19 @@
-import polars as pl
-import numpy as np
+from sqlmodel import Session, select
 
+from app.core.db import engine
+from app.models.transaction import JournalEntry
+
+
+def create_journal_entry(entry: JournalEntry) -> JournalEntry:
+    """Persist a journal entry and its lines."""
+    with Session(engine) as session:
+        session.add(entry)
+        session.commit()
+        session.refresh(entry)
+        return entry
+
+
+def list_journal_entries() -> list[JournalEntry]:
+    """Retrieve all journal entries."""
+    with Session(engine) as session:
+        return session.exec(select(JournalEntry)).all()

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,37 @@
+from sqlmodel import Session, select
+
+from app.core.db import engine, init_db
+from app.models import (
+    AccountCategory,
+    ChartOfAccount,
+    JournalEntry,
+    JournalLine,
+)
+
+
+def test_journal_entry_persists_lines():
+    # Ensure tables exist
+    init_db()
+
+    with Session(engine) as session:
+        # create accounts
+        cash = ChartOfAccount(code="100", name="Cash", category=AccountCategory.ASSET)
+        revenue = ChartOfAccount(code="400", name="Revenue", category=AccountCategory.INCOME)
+        session.add(cash)
+        session.add(revenue)
+        session.commit()
+        session.refresh(cash)
+        session.refresh(revenue)
+
+        entry = JournalEntry(description="sale", lines=[
+            JournalLine(account_id=cash.id, debit=100),
+            JournalLine(account_id=revenue.id, credit=100),
+        ])
+        session.add(entry)
+        session.commit()
+        session.refresh(entry)
+
+        lines = session.exec(select(JournalLine).where(JournalLine.entry_id == entry.id)).all()
+        assert len(lines) == 2
+        assert sum(l.debit for l in lines) == 100
+        assert sum(l.credit for l in lines) == 100


### PR DESCRIPTION
## Summary
- model journal entries and journal lines for debit/credit tracking
- expose transaction API endpoints and services for persisting entries
- add test ensuring journal entry lines persist correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*
- `pip install sqlmodel "fastapi[standard]" -q` *(fails: Could not find a version that satisfies the requirement sqlmodel)*

------
https://chatgpt.com/codex/tasks/task_e_68990439df60832d82395536b3b4c9d3